### PR TITLE
Fix getDate off-by-one issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@
             }
         }
         var pre = date.getFullYear().toString() + ((date.getMonth() + 1) < 10 ? "0" + (date.getMonth() + 1).toString() : (date.getMonth() + 1).toString());
-        pre += ((date.getDate() + 1) < 10 ? "0" + date.getDate().toString() : date.getDate().toString());
+        pre += (date.getDate() < 10 ? "0" + date.getDate().toString() : date.getDate().toString());
 
         var post = originalDate.getHours() < 10 ? ("0" + originalDate.getHours().toString()) : (originalDate.getHours().toString());
         if(originalDate.getMinutes() == 0)
@@ -295,7 +295,7 @@
             }
         }
         var pre = date.getFullYear().toString() + ((date.getMonth() + 1) < 10 ? "0" + (date.getMonth() + 1).toString() : (date.getMonth() + 1).toString());
-        pre += ((date.getDate() + 1) < 10 ? "0" + date.getDate().toString() : date.getDate().toString());
+        pre += (date.getDate() < 10 ? "0" + date.getDate().toString() : date.getDate().toString());
 
         var post = originalDate.getHours() < 10 ? ("0" + originalDate.getHours().toString()) : (originalDate.getHours().toString());
         if(originalDate.getMinutes() == 0)


### PR DESCRIPTION
I was having an issue with one of my exams as well as a number of lectures and labs not showing up on my calendar, and it turns out since the lectures/labs started on September 9th and the exam was on December 9th, the code in `correctStartTime` and `correctEndTime` was not properly prepending the 0 in this case due to the `+ 1` after `getDate()`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate

`getDate()`, unlike `getMonth()` and `getDay()` which return 0-indexed values, returns the actual date number (so 1-(28-31)). So I think this change will fix issues with classes starting on the 9th and not introduce any other issue, unless there's something I'm missing. 😅 

After applying this fix, all my classes and my Monday exam appeared on my schedule without any apparent issues.

As an additional note, I'm surprised I haven't run into this issue until now. 🤔 Looked quickly on my calendar and it seems like the last time a Tuesday,Thursday lecture/lab started on the 9th was back in January 2018 and the last time a Monday,Wednesday,Friday lecture/lab started on the 9th was back in January 2017.