### PR TITLE
Update README to include local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Course2iCal
 Allows users to paste in their University of Guelph schedule and it will export it to iCal or allow them to export it to various calendar programs.
 
+## Installation
+To run Course2iCal locally, you can run the following command to start a local PHP server: (assuming `php` is installed on your system and in your PATH)
+
+```
+php -S localhost:8000
+```
+
 Tested with <a href="https://www.browserstack.com/"><img src="./img/Browserstack-logo@2x.png" width="25%" height="25%"></a>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Course2iCal
 Allows users to paste in their University of Guelph schedule and it will export it to iCal or allow them to export it to various calendar programs.
 
-## Installation
-To run Course2iCal locally, you can run the following command to start a local PHP server on port 8000: (assuming `php` is installed on your system and in your PATH)
+## Development Setup
+You can simply open `index.html` on your browser to test out most functionality of Course2iCal.
+
+If you would like to work on the logging functionality, you can run the following command to start a local PHP server on port 8000: (assuming `php` is installed on your system and in your PATH)
 
 ```
 php -S localhost:8000

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Allows users to paste in their University of Guelph schedule and it will export it to iCal or allow them to export it to various calendar programs.
 
 ## Installation
-To run Course2iCal locally, you can run the following command to start a local PHP server: (assuming `php` is installed on your system and in your PATH)
+To run Course2iCal locally, you can run the following command to start a local PHP server on port 8000: (assuming `php` is installed on your system and in your PATH)
 
 ```
 php -S localhost:8000


### PR DESCRIPTION
Haven't really used PHP since 2750 so it was not immediately obvious to me that you can spin up a local PHP server to test. I added this passage into the README for people wanting to contribute who are unsure how to run it locally.