### PR TITLE
Fix events with 'Days TBA' preventing calendar import on Google Calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
                     results.push('SU');
                     break;
                 default:
-                    results.push('Days of the week incorrect');
+                    results.push('INVALID');
             }
         }
         return results.join();
@@ -357,8 +357,13 @@
                     ical += 'DTSTART:' + correctStartTime(startDate, getCourseTime(splitCourse[j + 1], 'start', getCourseType(splitCourse[j])), getDays(splitCourse[j])) + '\n';
                     ical += 'DTEND:' + correctEndTime(startDate, getCourseTime(splitCourse[j + 1], 'end', getCourseType(splitCourse[j])), getDays(splitCourse[j])) + '\n';
                 }
-                if(getCourseType(splitCourse[j]) != "EXAM")
-                    ical += 'RRULE:FREQ=WEEKLY;UNTIL='+ term.termEnd +';WKST=SU;BYDAY=' + convertArrayOfDatesToICSFormat(getArrayOfDates(getDays(splitCourse[j]))) + '\n';
+                if(getCourseType(splitCourse[j]) != "EXAM") {
+                    ical += 'RRULE:FREQ=WEEKLY;UNTIL='+ term.termEnd +';WKST=SU';
+                    icsDates = convertArrayOfDatesToICSFormat(getArrayOfDates(getDays(splitCourse[j])))
+                    if (!icsDates.includes("INVALID"))
+                        ical += ';BYDAY=' + icsDates;
+                    ical += '\n'
+                }
                 ical += 'SUMMARY:' + '(' + getCourseType(splitCourse[j]) + ') '  + courseCode + '\n';
                 ical += 'LOCATION:' + getCourseLocation(splitCourse[j+2]) + ', University of Guelph\n';
                 ical += 'DESCRIPTION:' + courseCode + '\n';


### PR DESCRIPTION
This should fix #14. Imported the schedule mentioned in the issue into Google Calendar, Outlook Calendar, and Apple Calendar without any apparent issues.

This should not affect any schedules which don't have a class with "Days TBA".

Also updated the invalid text from "Days of the week incorrect" to "INVALID".

@Fogest The TBA event will still appear on their calendars on midnight Sunday even with this fix, but I think this is OK because perhaps the user would like to manually adjust this event on their calendar. What do you think?