### PR TITLE
Add warning messages for DaysTBA and invalid days

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,13 @@
             Your browser does not support the video tag.
         </video>
     </div>
+
+    <div style="display:none" id="parseWarn" class="alert alert-warning" role="alert">
+        <ul style="margin-bottom:10px" class="warnMessages list-group list-group-flush">
+        </ul>
+        If you're having problems feel free to send an email, use the chat support, or checkout our
+        <a href="https://www.facebook.com/course2calendar/">Facebook page</a> for support!
+    </div>
 	
 	<div style="display:none" class="errorParse alert alert-danger" role="alert">
 		<b>Oh no!</b> There was a problem processing your data. 
@@ -359,9 +366,16 @@
                 }
                 if(getCourseType(splitCourse[j]) != "EXAM") {
                     ical += 'RRULE:FREQ=WEEKLY;UNTIL='+ term.termEnd +';WKST=SU';
-                    icsDates = convertArrayOfDatesToICSFormat(getArrayOfDates(getDays(splitCourse[j])))
+                    var dates = getArrayOfDates(getDays(splitCourse[j]));
+                    var icsDates = convertArrayOfDatesToICSFormat(dates);
                     if (!icsDates.includes("INVALID"))
                         ical += ';BYDAY=' + icsDates;
+                    else {
+                        var invalidDay = dates.includes('DaysTBA') ? '"Days TBA" set as the day it occurs' : 'an invalid day';
+                        var warnMsg = 'Your course "' + courseCode + '" has ' + invalidDay + '. This entry may show up on your calendar in an undesired manner, and will require manual adjustment.';
+                        addWarningMessage(warnMsg);
+                        $("#parseWarn").show();
+                    }
                     ical += '\n'
                 }
                 ical += 'SUMMARY:' + '(' + getCourseType(splitCourse[j]) + ') '  + courseCode + '\n';
@@ -385,6 +399,14 @@
     		url: "log.php",
     		data: {data: content}
     	});
+    }
+
+    function addWarningMessage(msg) {
+        $("#parseWarn .warnMessages").append('<li class="warnMessage list-group-item-warning list-group-item">' + msg + '</li>');
+    }
+
+    function clearWarningMessages() {
+        $("#parseWarn .warnMessages").empty();
     }
 
     /**
@@ -414,6 +436,8 @@
         e.preventDefault();
         logRequest($("#coursePasteContent").val())
         $(".resultContent").slideUp(300);
+        clearWarningMessages();
+        $("#parseWarn").hide();
         var status = parsePasteContent($("#coursePasteContent").val());
 
         //Reveal content if success:

--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@
     }
 
     function addWarningMessage(msg) {
-        $("#parseWarn .warnMessages").append('<li class="warnMessage list-group-item-warning list-group-item">' + msg + '</li>');
+        $("#parseWarn .warnMessages").append($('<li class="warnMessage list-group-item-warning list-group-item"></li>').text(msg));
     }
 
     function clearWarningMessages() {


### PR DESCRIPTION
- Give users warning for "Days TBA" day on one of their courses, printing out the course name as well for their convenience.
- Added a new warning message box that can be reused for future warnings
- Warnings can stack by calling `addWarningMessage` multiple times
- Also add "invalid day" generic warning for the case that some other garbage is there
- When user clicks button to generate iCal file, warning messages will be cleared and box will be hidden, and only an actual warning will make it show again
- Tested the following cases:
    - User has "Days TBA" event
<img width="959" alt="image" src="https://user-images.githubusercontent.com/3276350/64579229-1bdfb180-d350-11e9-96bf-4907c1d96694.png">
    - User has two "Days TBA" events
<img width="959" alt="image" src="https://user-images.githubusercontent.com/3276350/64579238-2437ec80-d350-11e9-9d5e-a3311970d731.png">
    - User has an invalid day event
<img width="959" alt="image" src="https://user-images.githubusercontent.com/3276350/64579243-2a2dcd80-d350-11e9-8d9d-ec294e86f755.png">
    - User has no invalid day events (no warning message box will appear, as it was previously)


edit:
- First and third cases plus HTML escape from course code on Safari
<img width="959" alt="image" src="https://user-images.githubusercontent.com/3276350/64580549-bfcb5c00-d354-11e9-89c8-4077c0251e79.png">

