### PR TITLE
Update Regex for term string

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
     }
 
     function getTerm(content) {
-        var term = /^.+\s201\d$/gm.exec(content);
+        var term = /^(Summer|Fall|Winter)\s\d{4}$/gm.exec(content);
         term = term[0];
         term = term.split(" ");
         term = term[0].charAt(0).toUpperCase() + term[1].charAt(2) + term[1].charAt(3);


### PR DESCRIPTION
Should fix #19. Tested it with my own Winter 2020 schedule and ics file generates successfully. My Fall 2019 schedule also generates successfully, so the new regex is backwards compatible. Works on Firefox, Chrome, and Safari.

I came up with a few Regexes we can use for this solution, listed below. I like the second one the best so I went with that.

`/^.+\s20\d{2}$/`
Concise and should last us 80 more years. I did not go with this because I wanted something more robust.

Regex result just has a single result, the term name string e.g. "Winter 2020". We use the first result only so this has always worked fine.

`/^(Summer|Fall|Winter)\s\d{4}$/`
Much more verbose but is pretty robust. However, assumes that terms can only be in the Summer, Fall, and Winter.

Regex result has two results, in order the term name string e.g. "Winter 2020" and the season name e.g. "Winter", but we just grab the first result so it should work the same.

`/^.+\s202\d$/`
Even less verbose than the first solution and will also work since people won't be making schedules for the previous decade anymore. Will have to update in 2030 however.

Regex result is also just one string, the term name string, like the first regex.

We can revisit the first or third Regexes if the second one doesn't end up working for someone. If you prefer the other ones @Fogest I can make another PR to switch over to one of them.




